### PR TITLE
Protected share button from spamming

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -87,7 +87,14 @@ function build_note(id, text, url) {
   let share_button = document.createElement("button");
   share_button.onclick = async () => {
 
+    share_button.setAttribute('disabled', true);
+    share_button.innerText = "Sharing...";
+
     const share_link = await share(id, text);
+
+    share_button.removeAttribute('disabled');
+    share_button.innerText = "Share";
+
     const note = await get_single_note(id);
     const data = {}
 


### PR DESCRIPTION
Great project! I'd have probably not come across it hadn't it been for Hacktoberfest. 😄

Spotted a minor bug when I started actively using it; on slow networks the delay between clicking the "share" button and the opening of a new tab is significant, during which, spamming the button multiple times opens the new tab as many times.

## Before Fix

![notes-bug](https://user-images.githubusercontent.com/15625446/136098250-93559f72-4b00-4835-8a3c-2d49de3a6e04.gif)

_I clicked / spammed the "share" button 3 times and the new tab is opened thrice._

## After Fix

![notes-bug-fix](https://user-images.githubusercontent.com/15625446/136098293-133759a9-9d79-4dff-8849-b97181a348a2.gif)

_The button is disabled when the `fetch` inside `share(id, data)` is being processed and a visual cue is shown to the user by changing the button text._